### PR TITLE
Remove roassal3 dependency from baseline for pharo 9

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,22 +5,13 @@ A connector to Roassal3 graphic engine
 
 ## Installation
 
-To install Telescope and the Roassal3, you simply need to execute the following code snippet in a playground in Pharo 8:
+To install Telescope and Roassal3, you simply need to execute the following code snippet in a playground in Pharo 8 or 9:
 ```Smalltalk
 Metacello new
     baseline: 'TelescopeRoassal3';
     repository: 'github://TelescopeSt/TelescopeRoassal3';
     load.
 ```
-
-In Pharo 9, you may want to use the following script (in order to avoid odd warnings from Metacello):
-
-```Smalltalk
-[Metacello new
-    baseline: 'TelescopeRoassal3';
-    repository: 'github://TelescopeSt/TelescopeRoassal3';
-    load ] on: MCMergeOrLoadWarning do: [:warning | warning load ]
-```  
 
 Note that this code snippet also loads Telescope, there is no need to load [Telescope](https://github.com/TelescopeSt/Telescope) therefore.
 

--- a/src/BaselineOfTelescopeRoassal3/BaselineOfTelescopeRoassal3.class.st
+++ b/src/BaselineOfTelescopeRoassal3/BaselineOfTelescopeRoassal3.class.st
@@ -9,36 +9,40 @@ Class {
 
 { #category : #baselines }
 BaselineOfTelescopeRoassal3 >> baseline: spec [
+
 	<baseline>
-	spec
-		for: #common
-		do: [
-			"our dependencies"
-			"https://github.com/TelescopeSt/TelescopeRoassal3/"
-			spec baseline: 'Roassal3' with: [ 
-				spec repository: 'github://ObjectProfile/Roassal3' ].
-			spec baseline: 'Telescope' with: [ 
-				spec repository: 'github://TelescopeSt/Telescope:v2.x.x/src' ].
-			
-			"The packages to use, but not load"
-			spec
-				package: #'Telescope-Roassal3' with: [ spec requires: #('Roassal3' 'Telescope') ];
-				package: #'Telescope-Roassal3-Tests'.
+	self pharo8: spec.
+	self pharo9: spec.
 
-			"packages to load"
-			
-			spec 
-				group: 'default' with: #(
-					'Telescope-Roassal3'
-					'Telescope-Roassal3-Tests') ].
+	spec for: #common do: [ 
+		spec
+			baseline: 'Telescope'
+			with: [ 
+			spec repository: 'github://TelescopeSt/Telescope:v2.x.x/src' ].
+		spec package: #'Telescope-Roassal3-Tests'.
 
-		
-	
+		spec
+			group: 'default'
+			with: #( 'Telescope-Roassal3' 'Telescope-Roassal3-Tests' ) ]
+]
 
+{ #category : #baselines }
+BaselineOfTelescopeRoassal3 >> pharo8: spec [
 
+	spec for: #'pharo8.x' do: [ 
+		spec
+			baseline: 'Roassal3'
+			with: [ spec repository: 'github://ObjectProfile/Roassal3' ].
+		spec
+			package: #'Telescope-Roassal3'
+			with: [ spec requires: #( 'Roassal3' 'Telescope' ) ] ]
+]
 
+{ #category : #baselines }
+BaselineOfTelescopeRoassal3 >> pharo9: spec [
 
-
-
-
+	spec for: #'pharo9.x' do: [ 
+		spec
+			package: #'Telescope-Roassal3'
+			with: [ spec requires: #( 'Telescope' ) ] ]
 ]


### PR DESCRIPTION
Not needed anymore since Roassal3 is integrated into Pharo.
Like this, there is no need for ```on: MCMergeOrLoadWarning ...``` guard in loading script.

It makes it easier to depend on this bridge in another baseline.