### PR TITLE
Add compatibility to Pharo 10

### DIFF
--- a/src/BaselineOfTelescopeRoassal3/BaselineOfTelescopeRoassal3.class.st
+++ b/src/BaselineOfTelescopeRoassal3/BaselineOfTelescopeRoassal3.class.st
@@ -12,7 +12,7 @@ BaselineOfTelescopeRoassal3 >> baseline: spec [
 
 	<baseline>
 	self pharo8: spec.
-	self pharo9: spec.
+	self pharo9AndLater: spec.
 
 	spec for: #common do: [ 
 		spec
@@ -39,9 +39,9 @@ BaselineOfTelescopeRoassal3 >> pharo8: spec [
 ]
 
 { #category : #baselines }
-BaselineOfTelescopeRoassal3 >> pharo9: spec [
+BaselineOfTelescopeRoassal3 >> pharo9AndLater: spec [
 
-	spec for: #'pharo9.x' do: [ 
+	spec for: #( #'pharo9.x' #'pharo10.x' ) do: [ 
 		spec
 			package: #'Telescope-Roassal3'
 			with: [ spec requires: #( 'Telescope' ) ] ]

--- a/src/Telescope-Roassal3/TLRoassal3Connector.class.st
+++ b/src/Telescope-Roassal3/TLRoassal3Connector.class.st
@@ -409,26 +409,26 @@ TLRoassal3Connector >> nodesShapesAvailableForConnector [
 ]
 
 { #category : #opening }
-TLRoassal3Connector >> open: aTLVisualization inWindowSized: aDimension titled: aString [ 
-	| window inspector lb controller |
+TLRoassal3Connector >> open: aTLVisualization inWindowSized: aDimension titled: aString [
+
+	| inspector lb controller |
 	view := RSCanvas new.
-	view inspectorContext: RSEmptyContext new.
+	view inspectorContext: RSEmptyContextInteraction new.
 	controller := RSCanvasController new noLegend.
 	view
 		@ controller;
 		@ TLDragPointCanvas.
 	firstTimeAnimation := true.
 	aTLVisualization generateWith: self.
-	lastPositions := nil. 
+	lastPositions := nil.
 	firstTimeAnimation := false.
 	lb := self legendBuilder.
-	lb shapes ifNotEmpty: [ lb build]. 
-	
-	inspector := GTInspector new.
-	window := inspector openOn: view.
-	inspector title: aString.
-	window extent: aDimension.
-	
+	lb shapes ifNotEmpty: [ lb build ].
+
+	inspector := Smalltalk tools inspector openOn: view.
+	inspector window
+		title: aString;
+		extent: aDimension
 ]
 
 { #category : #'generation - node' }


### PR DESCRIPTION
- Added Pharo 10 in baseline.
- Fixed demos using `Smalltalk tools inspector` instead of a specific inspector class, to keep compatibility with Pharo 8.